### PR TITLE
added timeout support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Lusitaniae/phpfpm_exporter
 go 1.16
 
 require (
+	github.com/kanocz/fcgi_client v0.0.0-20210113082628-fff85c8adfb7
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.27.0

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,5 @@ require (
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.27.0
-	github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19 h1:ZCmSnT6CLGhfoQ2lPEhL4nsJstKDCw1F1RfN8/smTCU=
-github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19/go.mod h1:SXTY+QvI+KTTKXQdg0zZ7nx0u94QWh8ZAwBQYsW9cqk=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/kanocz/fcgi_client v0.0.0-20210113082628-fff85c8adfb7 h1:W0fAsQ7bC1db4k9O2X6yZvatz/0c/ISyxhmNnc6arZA=
+github.com/kanocz/fcgi_client v0.0.0-20210113082628-fff85c8adfb7/go.mod h1:dHpIS7C6YjFguh5vo9QBVEojDoL3vh3v6oEho2HtNyA=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/phpfpm_exporter.go
+++ b/phpfpm_exporter.go
@@ -94,17 +94,38 @@ var (
 			"Enable php-fpm slow-log before you consider this. If this value is non-zero you may have slow php processes.",
 			[]string{phpfpmSocketPathLabel}, nil),
 	}
+
+
+	phpfpmStateGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "php",
+			Subsystem: "fpm",
+			Name:	  "state_count",
+			Help:	  "Count of PHP-FPM processes in each state.",
+		},
+		[]string{phpfpmSocketPathLabel, "state"},
+	)
 )
 
 func CollectStatusFromReader(reader io.Reader, socketPath string, ch chan<- prometheus.Metric) error {
 	scanner := bufio.NewScanner(reader)
 	re := regexp.MustCompile("^(.*): +(.*)$")
 
+	// Map to store the counts of each state
+	stateCounts := make(map[string]float64)
+
 	// Scrape the interesting values:
 	for scanner.Scan() {
 		fields := re.FindStringSubmatch(scanner.Text())
+		//fmt.Println(fields)
 		if fields == nil {
-			return fmt.Errorf("Failed to parse %s", scanner.Text())
+			continue // Can't return error since there are 2 rows empy and asterisks
+			//return fmt.Errorf("Failed to parse %s", scanner.Text())
+		}
+
+		if fields[1] == "state" {
+			// Increment the count for the state
+			stateCounts[fields[2]]++
 		}
 
 		if gauge, ok := phpfpmGauges[fields[1]]; ok {
@@ -144,6 +165,12 @@ func CollectStatusFromReader(reader io.Reader, socketPath string, ch chan<- prom
 				socketPath)
 		}
 	}
+
+	// Export the state counts as metrics
+	for state, count := range stateCounts {
+		phpfpmStateGauge.WithLabelValues(socketPath, state).Set(count)
+	}
+
 	return nil
 }
 
@@ -153,6 +180,7 @@ func CollectStatusFromSocket(path *SocketPath, statusPath string, connectTimeout
 	env["SCRIPT_FILENAME"] = statusPath
 	env["SCRIPT_NAME"] = statusPath
 	env["REQUEST_METHOD"] = "GET"
+	env["QUERY_STRING"] = "full"
 
 	fcgi, err := fcgiclient.DialTimeout(path.Network, path.Address, connectTimeout)
 	if err != nil {
@@ -168,8 +196,16 @@ func CollectStatusFromSocket(path *SocketPath, statusPath string, connectTimeout
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
-	return CollectStatusFromReader(resp.Body, path.FormatStr(), ch)
+	// Read and print the full response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	//fmt.Println("Full response body from socket:", string(body))
+
+	return CollectStatusFromReader(strings.NewReader(string(body)), path.FormatStr(), ch)
 }
 
 func CollectMetricsFromScript(socketPaths []*SocketPath, connectTimeout time.Duration, operationTimeout time.Duration, scriptPaths []string) ([]*client_model.MetricFamily, error) {
@@ -332,6 +368,7 @@ func main() {
 		panic(err)
 	}
 	prometheus.MustRegister(exporter)
+	prometheus.MustRegister(phpfpmStateGauge)
 
 	gatherer := prometheus.DefaultGatherer
 	if len(*scriptCollectorPaths) != 0 {

--- a/phpfpm_exporter.go
+++ b/phpfpm_exporter.go
@@ -28,12 +28,12 @@ import (
 
 	"path/filepath"
 
+	fcgiclient "github.com/kanocz/fcgi_client"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	client_model "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/version"
-    fcgiclient "github.com/kanocz/fcgi_client"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -160,9 +160,9 @@ func CollectStatusFromSocket(path *SocketPath, statusPath string, connectTimeout
 	}
 	defer fcgi.Close()
 
-    if operationTimeout > 0 {
-        fcgi.SetTimeout(operationTimeout)
-    }
+	if operationTimeout > 0 {
+		fcgi.SetTimeout(operationTimeout)
+	}
 
 	resp, err := fcgi.Get(env)
 	if err != nil {
@@ -183,9 +183,9 @@ func CollectMetricsFromScript(socketPaths []*SocketPath, connectTimeout time.Dur
 			}
 			defer fcgi.Close()
 
-            if operationTimeout > 0 {
-                fcgi.SetTimeout(operationTimeout)
-            }
+			if operationTimeout > 0 {
+				fcgi.SetTimeout(operationTimeout)
+			}
 
 			env := make(map[string]string)
 			env["DOCUMENT_ROOT"] = path.Dir(scriptPath)
@@ -227,18 +227,18 @@ func CollectMetricsFromScript(socketPaths []*SocketPath, connectTimeout time.Dur
 }
 
 type PhpfpmExporter struct {
-	socketPaths         []*SocketPath
-    connectTimeout      time.Duration
-	operationTimeout    time.Duration
-	statusPath          string
+	socketPaths			[]*SocketPath
+	connectTimeout		time.Duration
+	operationTimeout	time.Duration
+	statusPath			string
 }
 
 func NewPhpfpmExporter(socketPaths []*SocketPath, connectTimeout time.Duration, operationTimeout time.Duration, statusPath string) (*PhpfpmExporter, error) {
 	return &PhpfpmExporter{
-		socketPaths:        socketPaths,
-        connectTimeout:     connectTimeout,
-        operationTimeout:   operationTimeout,
-		statusPath:         statusPath,
+		socketPaths:		socketPaths,
+		connectTimeout:		connectTimeout,
+		operationTimeout:   operationTimeout,
+		statusPath:			statusPath,
 	}, nil
 }
 
@@ -294,15 +294,15 @@ func NewSocketPath(socketPath string) *SocketPath {
 
 func main() {
 	var (
-		listenAddress           = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9253").String()
-		metricsPath             = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
-		socketPaths             = kingpin.Flag("phpfpm.socket-paths", "Paths of the PHP-FPM sockets.").Strings()
-		socketDirectories       = kingpin.Flag("phpfpm.socket-directories", "Path(s) of the directory where PHP-FPM sockets are located.").Strings()
-		statusPath              = kingpin.Flag("phpfpm.status-path", "Path which has been configured in PHP-FPM to show status page.").Default("/status").String()
-		scriptCollectorPaths    = kingpin.Flag("phpfpm.script-collector-paths", "Paths of the PHP file whose output needs to be collected.").Strings()
-        socketConnectionTimeout = kingpin.Flag("phpfpm.connection-timeout", "Connection timeout for PHP-FPM sockets.").Duration()
+		listenAddress			= kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9253").String()
+		metricsPath				= kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
+		socketPaths				= kingpin.Flag("phpfpm.socket-paths", "Paths of the PHP-FPM sockets.").Strings()
+		socketDirectories		= kingpin.Flag("phpfpm.socket-directories", "Path(s) of the directory where PHP-FPM sockets are located.").Strings()
+		statusPath				= kingpin.Flag("phpfpm.status-path", "Path which has been configured in PHP-FPM to show status page.").Default("/status").String()
+		scriptCollectorPaths	= kingpin.Flag("phpfpm.script-collector-paths", "Paths of the PHP file whose output needs to be collected.").Strings()
+		socketConnectionTimeout = kingpin.Flag("phpfpm.connection-timeout", "Connection timeout for PHP-FPM sockets.").Duration()
 		socketOperationTimeout  = kingpin.Flag("phpfpm.operation-timeout", "Read/write operation timeout for PHP-FPM sockets.").Duration()
-		showVersion             = kingpin.Flag("version", "Print version information.").Bool()
+		showVersion				= kingpin.Flag("version", "Print version information.").Bool()
 	)
 
 	kingpin.CommandLine.HelpFlag.Short('h')

--- a/phpfpm_exporter.go
+++ b/phpfpm_exporter.go
@@ -227,18 +227,18 @@ func CollectMetricsFromScript(socketPaths []*SocketPath, connectTimeout time.Dur
 }
 
 type PhpfpmExporter struct {
-	socketPaths         []*SocketPath
-	connectTimeout      time.Duration
-	operationTimeout    time.Duration
-	statusPath          string
+	socketPaths      []*SocketPath
+	connectTimeout   time.Duration
+	operationTimeout time.Duration
+	statusPath       string
 }
 
 func NewPhpfpmExporter(socketPaths []*SocketPath, connectTimeout time.Duration, operationTimeout time.Duration, statusPath string) (*PhpfpmExporter, error) {
 	return &PhpfpmExporter{
-		socketPaths:        socketPaths,
-		connectTimeout:     connectTimeout,
-		operationTimeout:   operationTimeout,
-		statusPath:         statusPath,
+		socketPaths:      socketPaths,
+		connectTimeout:   connectTimeout,
+		operationTimeout: operationTimeout,
+		statusPath:       statusPath,
 	}, nil
 }
 

--- a/phpfpm_exporter.go
+++ b/phpfpm_exporter.go
@@ -227,18 +227,18 @@ func CollectMetricsFromScript(socketPaths []*SocketPath, connectTimeout time.Dur
 }
 
 type PhpfpmExporter struct {
-	socketPaths			[]*SocketPath
-	connectTimeout		time.Duration
-	operationTimeout	time.Duration
-	statusPath			string
+	socketPaths         []*SocketPath
+	connectTimeout      time.Duration
+	operationTimeout    time.Duration
+	statusPath          string
 }
 
 func NewPhpfpmExporter(socketPaths []*SocketPath, connectTimeout time.Duration, operationTimeout time.Duration, statusPath string) (*PhpfpmExporter, error) {
 	return &PhpfpmExporter{
-		socketPaths:		socketPaths,
-		connectTimeout:		connectTimeout,
+		socketPaths:        socketPaths,
+		connectTimeout:     connectTimeout,
 		operationTimeout:   operationTimeout,
-		statusPath:			statusPath,
+		statusPath:         statusPath,
 	}, nil
 }
 
@@ -294,15 +294,15 @@ func NewSocketPath(socketPath string) *SocketPath {
 
 func main() {
 	var (
-		listenAddress			= kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9253").String()
-		metricsPath				= kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
-		socketPaths				= kingpin.Flag("phpfpm.socket-paths", "Paths of the PHP-FPM sockets.").Strings()
-		socketDirectories		= kingpin.Flag("phpfpm.socket-directories", "Path(s) of the directory where PHP-FPM sockets are located.").Strings()
-		statusPath				= kingpin.Flag("phpfpm.status-path", "Path which has been configured in PHP-FPM to show status page.").Default("/status").String()
-		scriptCollectorPaths	= kingpin.Flag("phpfpm.script-collector-paths", "Paths of the PHP file whose output needs to be collected.").Strings()
+		listenAddress           = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9253").String()
+		metricsPath             = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
+		socketPaths             = kingpin.Flag("phpfpm.socket-paths", "Paths of the PHP-FPM sockets.").Strings()
+		socketDirectories       = kingpin.Flag("phpfpm.socket-directories", "Path(s) of the directory where PHP-FPM sockets are located.").Strings()
+		statusPath              = kingpin.Flag("phpfpm.status-path", "Path which has been configured in PHP-FPM to show status page.").Default("/status").String()
+		scriptCollectorPaths    = kingpin.Flag("phpfpm.script-collector-paths", "Paths of the PHP file whose output needs to be collected.").Strings()
 		socketConnectionTimeout = kingpin.Flag("phpfpm.connection-timeout", "Connection timeout for PHP-FPM sockets.").Duration()
 		socketOperationTimeout  = kingpin.Flag("phpfpm.operation-timeout", "Read/write operation timeout for PHP-FPM sockets.").Duration()
-		showVersion				= kingpin.Flag("version", "Print version information.").Bool()
+		showVersion             = kingpin.Flag("version", "Print version information.").Bool()
 	)
 
 	kingpin.CommandLine.HelpFlag.Short('h')


### PR DESCRIPTION
Hi, this should be fix for https://github.com/Lusitaniae/phpfpm_exporter/issues/17, where i wasn't active, since we modified your version and create test for from one of our devs. Then it I forgot about this until we needed support for TCP/IP sockets.

Our dev created https://github.com/kanocz/phpfpm_exporter/commit/2c6a8e892ebb61292b639b73be8d8e8917f06a08 with his modified fcgi_client https://github.com/tomasen/fcgi_client/commit/fff85c8adfb7b9123ae30f38e21fa21a996703c8 . This isnt merged into tomasen still, so I used his now as well.

I do not understand go that much, but i was able to merge your master with his changes with working prototype. I deployd this PR in our setup ~200 servers with FPM ranging from 1-300 sockets per server, so it works.

In log it can be seen when timeout are set for 2s, it works and on high load server we are able to get responses for all sockets even if few of them hangs.

```
2024/04/26 09:27:51 Failed to scrape socket: read unix @->/var/lib/php/8.0/fpm/name0.sock: i/o timeout
2024/04/26 09:27:54 Failed to scrape socket: read unix @->/var/lib/php/8.0/fpm/name1.sock: i/o timeout
2024/04/26 09:27:56 Failed to scrape socket: read unix @->/var/lib/php/8.0/fpm/name2.sock: i/o timeout
2024/04/26 09:27:58 Failed to scrape socket: read unix @->/var/lib/php/8.0/fpm/name3.sock: i/o timeout
2024/04/26 09:27:58 Failed to scrape socket: dial unix /var/lib/php/8.0/fpm/name5.sock: connect: resource temporarily unavailable
```

If this is merged it should close my open issue.