### PR TITLE
added counting of connection state for sockets

### DIFF
--- a/phpfpm_exporter.go
+++ b/phpfpm_exporter.go
@@ -99,8 +99,8 @@ var (
 		prometheus.GaugeOpts{
 			Namespace: "php",
 			Subsystem: "fpm",
-			Name:	    "state_count",
-			Help:	    "Count of PHP-FPM processes in each state.",
+			Name:      "state_count",
+			Help:      "Count of PHP-FPM processes in each state.",
 		},
 		[]string{phpfpmSocketPathLabel, "state"},
 	)

--- a/phpfpm_exporter.go
+++ b/phpfpm_exporter.go
@@ -95,13 +95,12 @@ var (
 			[]string{phpfpmSocketPathLabel}, nil),
 	}
 
-
 	phpfpmStateGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "php",
 			Subsystem: "fpm",
-			Name:	  "state_count",
-			Help:	  "Count of PHP-FPM processes in each state.",
+			Name:	    "state_count",
+			Help:	    "Count of PHP-FPM processes in each state.",
 		},
 		[]string{phpfpmSocketPathLabel, "state"},
 	)


### PR DESCRIPTION
We had issue on one of our server, memcache was blocking some threads of FPM and they were stucked in "Finishing state"

This PR adding metriks like
```
# HELP php_fpm_state_count Count of PHP-FPM processes in each state.
# TYPE php_fpm_state_count gauge
php_fpm_state_count{socket_path="unix:///var/lib/php/8.1/fpm/test.cz.sock",state="Getting request information"} 3
php_fpm_state_count{socket_path="unix:///var/lib/php/8.1/fpm/test.cz.sock",state="Idle"} 28
php_fpm_state_count{socket_path="unix:///var/lib/php/8.1/fpm/test.cz.sock",state="Running"} 4
```

Based on info you get when calling 
```
~$ REQUEST_METHOD="GET" SCRIPT_NAME="/fpm-status" SCRIPT_FILENAME="/fpm-status" QUERY_STRING="full" cgi-fcgi -bind -connect /var/lib/php/8.1/fpm/test.cz.sock
```

If something need to be modified, with a bit of guidance i can fix it.